### PR TITLE
feat(repository-matcher): Add skipfolders, to skip scanning these folders

### DIFF
--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -25,10 +25,10 @@ func ExampleNewRepositoryMatcher() {
 
 	// Check files against hierarchical patterns
 	files := []string{
-		"app.log",                              // Matched by root .gitignore
-		"frontend/node_modules/pkg/index.js",   // Matched by frontend/.gitignore
-		"backend/target/classes/Main.class",    // Matched by backend/.gitignore
-		"frontend/src/App.js",                  // Not matched
+		"app.log",                            // Matched by root .gitignore
+		"frontend/node_modules/pkg/index.js", // Matched by frontend/.gitignore
+		"backend/target/classes/Main.class",  // Matched by backend/.gitignore
+		"frontend/src/App.js",                // Not matched
 	}
 
 	for _, file := range files {
@@ -52,9 +52,9 @@ func ExampleRepositoryMatcher_Matches() {
 	}
 
 	files := []string{
-		"file.txt",                  // Ignored by root
-		"important/file.txt",        // Still ignored by root
-		"important/critical.txt",    // Un-ignored by important/.gitignore
+		"file.txt",               // Ignored by root
+		"important/file.txt",     // Still ignored by root
+		"important/critical.txt", // Un-ignored by important/.gitignore
 	}
 
 	for _, file := range files {
@@ -71,9 +71,10 @@ func ExampleRepositoryMatcher_Matches() {
 // for repository matching, such as limiting depth or using custom ignore file names.
 func ExampleNewRepositoryMatcherWithConfig() {
 	config := &dotignore.RepositoryConfig{
-		IgnoreFileName: ".ignore",  // Use .ignore instead of .gitignore
-		MaxDepth:       3,           // Only search 3 levels deep
-		FollowSymlinks: false,       // Don't follow symbolic links
+		IgnoreFileName: ".ignore",                                     // Use .ignore instead of .gitignore
+		MaxDepth:       3,                                             // Only search 3 levels deep
+		FollowSymlinks: false,                                         // Don't follow symbolic links
+		SkipFolders:    []string{"node_modules", ".terragrunt-cache"}, // Don't search .gitignore in these folders
 	}
 
 	matcher, err := dotignore.NewRepositoryMatcherWithConfig("/path/to/repo", config)
@@ -113,9 +114,9 @@ func ExampleRepositoryMatcher_monorepo() {
 	// Global patterns apply everywhere
 	fmt.Println("Global patterns:")
 	globalFiles := []string{
-		"app.log",           // Matched by root
-		"frontend/app.log",  // Also matched by root
-		".DS_Store",         // Matched by root
+		"app.log",          // Matched by root
+		"frontend/app.log", // Also matched by root
+		".DS_Store",        // Matched by root
 	}
 	for _, file := range globalFiles {
 		ignored, _ := matcher.Matches(file)
@@ -125,9 +126,9 @@ func ExampleRepositoryMatcher_monorepo() {
 	// Subproject-specific patterns
 	fmt.Println("\nSubproject patterns:")
 	subprojectFiles := []string{
-		"frontend/node_modules/react/index.js",  // Frontend specific
-		"backend/target/output.jar",              // Backend specific
-		"docs/_build/html/index.html",            // Docs specific
+		"frontend/node_modules/react/index.js", // Frontend specific
+		"backend/target/output.jar",            // Backend specific
+		"docs/_build/html/index.html",          // Docs specific
 	}
 	for _, file := range subprojectFiles {
 		ignored, _ := matcher.Matches(file)

--- a/internal/util.go
+++ b/internal/util.go
@@ -34,6 +34,15 @@ func ReadLines(reader io.Reader) ([]string, error) {
 	return lines, nil
 }
 
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 // BuildRegex converts a gitignore-style pattern to a regular expression.
 // It properly handles wildcards, escaping, and gitignore-specific rules.
 func BuildRegex(pattern string) (*regexp.Regexp, error) {

--- a/internal/util.go
+++ b/internal/util.go
@@ -34,6 +34,7 @@ func ReadLines(reader io.Reader) ([]string, error) {
 	return lines, nil
 }
 
+// Contains checks if a slice contains a specific string.
 func Contains(slice []string, item string) bool {
 	for _, s := range slice {
 		if s == item {

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -301,6 +301,55 @@ func TestBuildRegexEdgeCases(t *testing.T) {
 	}
 }
 
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		item     string
+		expected bool
+	}{
+		{
+			name:     "Item present",
+			slice:    []string{"banana", "apple", "cherry"},
+			item:     "apple",
+			expected: true,
+		},
+		{
+			name:     "Item not present",
+			slice:    []string{"apple", "banana", "cherry"},
+			item:     "date",
+			expected: false,
+		},
+		{
+			name:     "Empty slice",
+			slice:    []string{},
+			item:     "apple",
+			expected: false,
+		},
+		{
+			name:     "Duplicate elements",
+			slice:    []string{"apple", "banana", "apple", "cherry"},
+			item:     "apple",
+			expected: true,
+		},
+		{
+			name:     "Case sensitive match",
+			slice:    []string{"Apple", "BANANA", "cherry"},
+			item:     "apple",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := Contains(test.slice, test.item)
+			if result != test.expected {
+				t.Errorf("Contains(%v, %q) = %v; expected %v", test.slice, test.item, result, test.expected)
+			}
+		})
+	}
+}
+
 func BenchmarkBuildRegex(b *testing.B) {
 	patterns := []string{
 		"*.txt",

--- a/repository.go
+++ b/repository.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -45,6 +46,9 @@ type RepositoryConfig struct {
 
 	// FollowSymlinks determines whether to follow symbolic links when discovering ignore files
 	FollowSymlinks bool
+
+	// SkipFolders list of foldernames to not search for IgnoreFileName-files.
+	SkipFolders []string
 }
 
 // DefaultRepositoryConfig returns a RepositoryConfig with sensible defaults.
@@ -53,6 +57,7 @@ func DefaultRepositoryConfig() *RepositoryConfig {
 		IgnoreFileName: ".gitignore",
 		MaxDepth:       0, // unlimited
 		FollowSymlinks: false,
+		SkipFolders:    make([]string, 0),
 	}
 }
 
@@ -116,6 +121,10 @@ func (rm *RepositoryMatcher) discoverIgnoreFiles(config *RepositoryConfig) error
 				return fs.SkipDir
 			}
 			return err
+		}
+
+		if d.IsDir() && slices.Contains(config.SkipFolders, d.Name()) {
+			return fs.SkipDir
 		}
 
 		// Check depth limit

--- a/repository.go
+++ b/repository.go
@@ -7,8 +7,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
+
+	"github.com/codeglyph/go-dotignore/v2/internal"
 )
 
 // RepositoryMatcher provides hierarchical .gitignore pattern matching that mirrors
@@ -123,7 +124,7 @@ func (rm *RepositoryMatcher) discoverIgnoreFiles(config *RepositoryConfig) error
 			return err
 		}
 
-		if d.IsDir() && slices.Contains(config.SkipFolders, d.Name()) {
+		if d.IsDir() && internal.Contains(config.SkipFolders, d.Name()) {
 			return fs.SkipDir
 		}
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -63,11 +63,11 @@ func TestNewRepositoryMatcher(t *testing.T) {
 		{
 			name: "deeply nested .gitignore",
 			structure: map[string]string{
-				".gitignore":                    "*.log\n",
-				"a/.gitignore":                  "*.tmp\n",
-				"a/b/.gitignore":                "*.cache\n",
-				"a/b/c/.gitignore":              "*.test\n",
-				"a/b/c/d/.gitignore":            "*.debug\n",
+				".gitignore":         "*.log\n",
+				"a/.gitignore":       "*.tmp\n",
+				"a/b/.gitignore":     "*.cache\n",
+				"a/b/c/.gitignore":   "*.test\n",
+				"a/b/c/d/.gitignore": "*.debug\n",
 			},
 			wantErr:   false,
 			wantCount: 5,
@@ -132,7 +132,7 @@ func TestNewRepositoryMatcher_Errors(t *testing.T) {
 
 func TestRepositoryMatcher_Matches_SimpleHierarchy(t *testing.T) {
 	structure := map[string]string{
-		".gitignore": "*.log\ntemp/\n",
+		".gitignore":          "*.log\ntemp/\n",
 		"frontend/.gitignore": "node_modules/\ndist/\n",
 	}
 
@@ -185,7 +185,7 @@ func TestRepositoryMatcher_Matches_SimpleHierarchy(t *testing.T) {
 
 func TestRepositoryMatcher_Matches_Negation(t *testing.T) {
 	structure := map[string]string{
-		".gitignore": "*.log\n!important.log\n",
+		".gitignore":      "*.log\n!important.log\n",
 		"logs/.gitignore": "!debug.log\n",
 	}
 
@@ -311,7 +311,7 @@ _build/
 func TestRepositoryMatcher_Matches_OverrideParentPatterns(t *testing.T) {
 	// Test that child .gitignore can override parent patterns
 	structure := map[string]string{
-		".gitignore": "*.txt\n",
+		".gitignore":         "*.txt\n",
 		"special/.gitignore": "!important.txt\n",
 	}
 
@@ -351,7 +351,7 @@ func TestRepositoryMatcher_Matches_OverrideParentPatterns(t *testing.T) {
 func TestRepositoryMatcher_Matches_RootRelativePatterns(t *testing.T) {
 	// Test root-relative patterns in nested .gitignore files
 	structure := map[string]string{
-		".gitignore": "/build/\nconfig/\n",
+		".gitignore":     "/build/\nconfig/\n",
 		"src/.gitignore": "/test/\n",
 	}
 
@@ -429,9 +429,9 @@ func TestRepositoryMatcher_Matches_AbsolutePaths(t *testing.T) {
 
 func TestRepositoryMatcher_IgnoreFilePaths(t *testing.T) {
 	structure := map[string]string{
-		".gitignore": "*.log\n",
+		".gitignore":          "*.log\n",
 		"frontend/.gitignore": "node_modules/\n",
-		"backend/.gitignore": "target/\n",
+		"backend/.gitignore":  "target/\n",
 	}
 
 	tmpDir := createTestRepo(t, structure)
@@ -463,10 +463,10 @@ func TestRepositoryMatcher_IgnoreFilePaths(t *testing.T) {
 
 func TestRepositoryMatcherWithConfig_MaxDepth(t *testing.T) {
 	structure := map[string]string{
-		".gitignore":                "*.log\n",
-		"a/.gitignore":              "*.tmp\n",
-		"a/b/.gitignore":            "*.cache\n",
-		"a/b/c/.gitignore":          "*.test\n",
+		".gitignore":       "*.log\n",
+		"a/.gitignore":     "*.tmp\n",
+		"a/b/.gitignore":   "*.cache\n",
+		"a/b/c/.gitignore": "*.test\n",
 	}
 
 	tmpDir := createTestRepo(t, structure)
@@ -493,7 +493,7 @@ func TestRepositoryMatcherWithConfig_MaxDepth(t *testing.T) {
 
 func TestRepositoryMatcherWithConfig_CustomIgnoreFileName(t *testing.T) {
 	structure := map[string]string{
-		".ignore": "*.log\n",
+		".ignore":     "*.log\n",
 		"src/.ignore": "*.tmp\n",
 	}
 
@@ -525,7 +525,7 @@ func TestRepositoryMatcherWithConfig_CustomIgnoreFileName(t *testing.T) {
 
 func TestRepositoryMatcher_Matches_WildcardPatterns(t *testing.T) {
 	structure := map[string]string{
-		".gitignore": "node_modules/\n**/*.test.js\n",
+		".gitignore":     "node_modules/\n**/*.test.js\n",
 		"src/.gitignore": "*.tmp\n",
 	}
 
@@ -573,9 +573,112 @@ func TestRepositoryMatcher_Matches_WildcardPatterns(t *testing.T) {
 	}
 }
 
+func TestRepositoryMatcherWithConfig_SkipFolders(t *testing.T) {
+	structure := map[string]string{
+		".gitignore":            "*.log\n",
+		"vendor/.gitignore":     "*.tmp\n",
+		"vendor/pkg/.gitignore": "*.cache\n",
+		"src/.gitignore":        "*.test\n",
+	}
+
+	tmpDir := createTestRepo(t, structure)
+	defer os.RemoveAll(tmpDir)
+
+	config := &RepositoryConfig{
+		IgnoreFileName: ".gitignore",
+		SkipFolders:    []string{"vendor"},
+	}
+
+	matcher, err := NewRepositoryMatcherWithConfig(tmpDir, config)
+	if err != nil {
+		t.Fatalf("NewRepositoryMatcherWithConfig() failed: %v", err)
+	}
+
+	// vendor/ and vendor/pkg/ .gitignore files should not be loaded
+	if count := matcher.IgnoreFileCount(); count != 2 {
+		t.Errorf("got %d ignore files, want 2 (root + src)", count)
+	}
+
+	tests := []struct {
+		path string
+		want bool
+		desc string
+	}{
+		{"app.log", true, "root pattern still applies"},
+		{"vendor/app.log", true, "root pattern applies inside skipped folder"},
+		{"vendor/cache.tmp", false, "vendor .gitignore not loaded - *.tmp not matched"},
+		{"vendor/pkg/data.cache", false, "vendor/pkg .gitignore not loaded - *.cache not matched"},
+		{"src/unit.test", true, "src .gitignore loaded normally"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := matcher.Matches(tt.path)
+			if err != nil {
+				t.Errorf("Matches(%q) error: %v", tt.path, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Matches(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryMatcherWithConfig_SkipFolders_Multiple(t *testing.T) {
+	structure := map[string]string{
+		".gitignore":              "*.log\n",
+		"vendor/.gitignore":       "*.tmp\n",
+		"node_modules/.gitignore": "*.cache\n",
+		"src/.gitignore":          "*.test\n",
+	}
+
+	tmpDir := createTestRepo(t, structure)
+	defer os.RemoveAll(tmpDir)
+
+	config := &RepositoryConfig{
+		IgnoreFileName: ".gitignore",
+		SkipFolders:    []string{"vendor", "node_modules"},
+	}
+
+	matcher, err := NewRepositoryMatcherWithConfig(tmpDir, config)
+	if err != nil {
+		t.Fatalf("NewRepositoryMatcherWithConfig() failed: %v", err)
+	}
+
+	// Only root and src should be loaded
+	if count := matcher.IgnoreFileCount(); count != 2 {
+		t.Errorf("got %d ignore files, want 2", count)
+	}
+}
+
+func TestRepositoryMatcherWithConfig_SkipFolders_Empty(t *testing.T) {
+	structure := map[string]string{
+		".gitignore":        "*.log\n",
+		"vendor/.gitignore": "*.tmp\n",
+	}
+
+	tmpDir := createTestRepo(t, structure)
+	defer os.RemoveAll(tmpDir)
+
+	config := &RepositoryConfig{
+		IgnoreFileName: ".gitignore",
+		SkipFolders:    []string{}, // empty - nothing skipped
+	}
+
+	matcher, err := NewRepositoryMatcherWithConfig(tmpDir, config)
+	if err != nil {
+		t.Fatalf("NewRepositoryMatcherWithConfig() failed: %v", err)
+	}
+
+	if count := matcher.IgnoreFileCount(); count != 2 {
+		t.Errorf("got %d ignore files, want 2", count)
+	}
+}
+
 func TestRepositoryMatcher_EmptyFile(t *testing.T) {
 	structure := map[string]string{
-		".gitignore": "",
+		".gitignore":     "",
 		"src/.gitignore": "*.tmp\n",
 	}
 


### PR DESCRIPTION
Hi,

I've created this PR because i was using the RepositoryMatcher on a large codebase with many .cache-folders.

I've extended the RepositoryConfig to include a property "SkipDirs". These list of folders will be ignored in `discoverIgnoreFiles`

Just another 5 cent: I highly suggest to run gofmt over the repo, it enforces a go-idiomatic format and less noice in PRs